### PR TITLE
A tiny performance improvement

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@ man/figures/
 tests/testthat/_snaps
 tests/testthat/test-fdf_ftf.R
 tests/testthat/test-standard_date_time.R
+^\.covrignore$

--- a/.covrignore
+++ b/.covrignore
@@ -1,0 +1,1 @@
+R/days_months.R

--- a/R/dt_replace.R
+++ b/R/dt_replace.R
@@ -7,6 +7,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   # This means we can use sub() instead of gsub()
 
   if ("G" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{G}", dt_G(input_dt, locale), dt, fixed = TRUE)
     dt <- sub("{GG}", dt_G(input_dt, locale), dt, fixed = TRUE)
     dt <- sub("{GGG}", dt_G(input_dt, locale), dt, fixed = TRUE)
@@ -34,6 +35,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("U" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{U}", dt_U(input_dt), dt, fixed = TRUE)
     dt <- sub("{UU}", dt_U(input_dt), dt, fixed = TRUE)
     dt <- sub("{UUU}", dt_U(input_dt), dt, fixed = TRUE)
@@ -47,6 +49,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("q" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{q}", dt_q(input_dt), dt, fixed = TRUE)
     dt <- sub("{qq}", dt_qq(input_dt), dt, fixed = TRUE)
     dt <- sub("{qqq}", dt_qqq(input_dt, locale), dt, fixed = TRUE)
@@ -64,6 +67,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("L" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{L}", dt_L(input_dt), dt, fixed = TRUE)
     dt <- sub("{LL}", dt_LL(input_dt), dt, fixed = TRUE)
     dt <- sub("{LLL}", dt_LLL(input_dt, locale), dt, fixed = TRUE)
@@ -72,6 +76,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("w" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{w}", dt_w(input_dt), dt, fixed = TRUE)
     dt <- sub("{ww}", dt_ww(input_dt), dt, fixed = TRUE)
   }
@@ -95,6 +100,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("E" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{E}", dt_E(input_dt, locale), dt, fixed = TRUE)
     dt <- sub("{EE}", dt_E(input_dt, locale), dt, fixed = TRUE)
     dt <- sub("{EEE}", dt_E(input_dt, locale), dt, fixed = TRUE)
@@ -104,6 +110,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("e" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{e}", dt_e(input_dt, locale), dt, fixed = TRUE)
     dt <- sub("{ee}", dt_ee(input_dt, locale), dt, fixed = TRUE)
     dt <- sub("{eee}", dt_eee(input_dt, locale), dt, fixed = TRUE)
@@ -113,6 +120,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("c" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{c}", dt_c(input_dt, locale), dt, fixed = TRUE)
     dt <- sub("{cc}", dt_cc(input_dt, locale), dt, fixed = TRUE)
     dt <- sub("{ccc}", dt_ccc(input_dt, locale), dt, fixed = TRUE)
@@ -122,6 +130,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("a" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{a}", dt_a(input_dt, locale), dt, fixed = TRUE)
     dt <- sub("{aa}", dt_a(input_dt, locale), dt, fixed = TRUE)
     dt <- sub("{aaa}", dt_a(input_dt, locale), dt, fixed = TRUE)
@@ -130,6 +139,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("b" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{b}", dt_b(input_dt, locale), dt, fixed = TRUE)
     dt <- sub("{bb}", dt_b(input_dt, locale), dt, fixed = TRUE)
     dt <- sub("{bbb}", dt_b(input_dt, locale), dt, fixed = TRUE)
@@ -138,6 +148,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("B" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{B}", dt_B(input_dt, locale), dt, fixed = TRUE)
     dt <- sub("{BB}", dt_B(input_dt, locale), dt, fixed = TRUE)
     dt <- sub("{BBB}", dt_B(input_dt, locale), dt, fixed = TRUE)
@@ -146,6 +157,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("h" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{h}", dt_h(input_dt), dt, fixed = TRUE)
     dt <- sub("{hh}", dt_hh(input_dt), dt, fixed = TRUE)
   }
@@ -159,26 +171,31 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("K" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{K}", dt_K(input_dt), dt, fixed = TRUE)
     dt <- sub("{KK}", dt_KK(input_dt), dt, fixed = TRUE)
   }
 
   if ("k" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{k}", dt_k(input_dt), dt, fixed = TRUE)
     dt <- sub("{kk}", dt_kk(input_dt), dt, fixed = TRUE)
   }
 
   if ("m" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{m}", dt_m(input_dt), dt, fixed = TRUE)
     dt <- sub("{mm}", dt_mm(input_dt), dt, fixed = TRUE)
   }
 
   if ("s" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{s}", dt_s(input_dt), dt, fixed = TRUE)
     dt <- sub("{ss}", dt_ss(input_dt), dt, fixed = TRUE)
   }
 
   if ("S" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{S}", dt_S(input_dt), dt, fixed = TRUE)
     dt <- sub("{SS}", dt_SS(input_dt), dt, fixed = TRUE)
     dt <- sub("{SSS}", dt_SSS(input_dt), dt, fixed = TRUE)
@@ -191,6 +208,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("A" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{A}", dt_A(input_dt), dt, fixed = TRUE)
     dt <- sub("{AA}", dt_AA(input_dt), dt, fixed = TRUE)
     dt <- sub("{AAA}", dt_AAA(input_dt), dt, fixed = TRUE)
@@ -203,6 +221,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("z" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{z}", dt_z(input_dt, tz_info, locale), dt, fixed = TRUE)
     dt <- sub("{zz}", dt_z(input_dt, tz_info, locale), dt, fixed = TRUE)
     dt <- sub("{zzz}", dt_z(input_dt, tz_info, locale), dt, fixed = TRUE)
@@ -210,6 +229,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("Z" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{Z}", dt_Z(input_dt, tz_info, locale), dt, fixed = TRUE)
     dt <- sub("{ZZ}", dt_Z(input_dt, tz_info, locale), dt, fixed = TRUE)
     dt <- sub("{ZZZ}", dt_Z(input_dt, tz_info, locale), dt, fixed = TRUE)
@@ -228,6 +248,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("V" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{V}", dt_V(input_dt, tz_info, locale), dt, fixed = TRUE)
     dt <- sub("{VV}", dt_VV(input_dt, tz_info, locale), dt, fixed = TRUE)
     dt <- sub("{VVV}", dt_VVV(input_dt, tz_info, locale), dt, fixed = TRUE)
@@ -235,6 +256,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("X" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{X}", dt_X(input_dt, tz_info, locale), dt, fixed = TRUE)
     dt <- sub("{XX}", dt_XX(input_dt, tz_info, locale), dt, fixed = TRUE)
     dt <- sub("{XXX}", dt_XXX(input_dt, tz_info, locale), dt, fixed = TRUE)
@@ -243,6 +265,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("x" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{x}", dt_x(input_dt, tz_info, locale), dt, fixed = TRUE)
     dt <- sub("{xx}", dt_xx(input_dt, tz_info, locale), dt, fixed = TRUE)
     dt <- sub("{xxx}", dt_xxx(input_dt, tz_info, locale), dt, fixed = TRUE)
@@ -251,6 +274,7 @@ dt_replace <- function(dt, input_dt, dt_lett, locale, tz_info) {
   }
 
   if ("g" %in% dt_lett) {
+    # TODO extract the exact substitution to do to avoid problematic
     dt <- sub("{g}", dt_g(input_dt), dt, fixed = TRUE)
     dt <- sub("{gg}", dt_gg(input_dt), dt, fixed = TRUE)
     dt <- sub("{ggg}", dt_ggg(input_dt), dt, fixed = TRUE)

--- a/R/fdt.R
+++ b/R/fdt.R
@@ -958,6 +958,11 @@ fdt <- function(
 
   dt_out <- rep_len(NA_character_, length(input))
 
+  # Verify if each entry has timezone (checking before loop for performance)
+  if (is.character(input)) {
+    tz_present <-  is_tz_present(input = input)
+  }
+
   for (i in seq_along(input)) {
 
     input_i <- input[i]
@@ -981,14 +986,13 @@ fdt <- function(
       time_present <- is_time_present(input = input_i)
 
       # Determine if tz information is present, either as:
-      # [1] a tz offset in hours from GMT
+      # [1] a tz offset in hours from GMT (defined above before loop)
       # [2] a long tz identifier (either canonical or an alias)
-
-      tz_present <- is_tz_present(input = input_i)
+      tz_present_i <- tz_present[i]
       long_tzid_present <- is_long_tzid_present(input = input_i)
 
       # Strip away tz information from the input and return as `input_str`
-      if (tz_present) {
+      if (tz_present_i) {
         input_str <- strip_tz(input = input_i)
       } else if (long_tzid_present) {
         input_str <- strip_long_tzid(input = input_i)
@@ -1108,7 +1112,7 @@ fdt <- function(
         tz_info$tz_short_specific <- get_tz_short_specific(long_tzid = tz_info$long_tzid, input_dt = input_dt)
         tz_info$tz_long_specific <- get_tz_long_specific(long_tzid = tz_info$long_tzid, input_dt = input_dt, locale = locale)
 
-      } else if (tz_present) {
+      } else if (tz_present_i) {
 
         tz_info$tz_str <- get_tz_str(input = input_i)
         tz_info$tz_offset <- get_tz_offset_val(input = input_i)
@@ -1254,7 +1258,7 @@ dt_format_pattern <- function(format) {
       unique(unlist(strsplit(format, "", fixed = TRUE))),
       sub_letters()
     )
-
+  # Bad error if length(dt_letters) == 0
   pattern <- paste0("(", paste0("[", dt_letters, "]+", collapse = "|"), ")")
 
   format <- gsub(pattern, "\\{\\1\\}", format)

--- a/R/utils-date_time_parse.R
+++ b/R/utils-date_time_parse.R
@@ -42,8 +42,8 @@ is_time_present <- function(input) {
   grepl(get_time_pattern(), input)
 }
 
+# returns a vector of length of input
 is_tz_present <- function(input) {
-
   regex <- paste(
     get_tz_pattern_z(),
     get_tz_pattern_hh(),
@@ -51,7 +51,7 @@ is_tz_present <- function(input) {
     get_tz_pattern_hhmm(),
     sep = "|"
   )
-  any(grepl(regex, input))
+  grepl(regex, input)
 }
 
 is_long_tzid_present <- function(input) {
@@ -323,21 +323,18 @@ get_localized_exemplar_city <- function(
 # The short specific non-location format (e.g., 'PST') from a `long_tzid`
 get_tz_short_specific <- function(long_tzid, input_dt) {
 
-  input_date <- as.Date(input_dt)
-
   tzdb_entries_tzid <- tzdb[tzdb$zone_name == long_tzid, ]
   if (nrow(tzdb_entries_tzid) == 0) {
     return(NA_character_)
   }
 
-  tzdb_idx <- rle(tzdb_entries_tzid$date_start >= input_date)$lengths[1]
+  input_date <- as.Date(input_dt)
 
-  tz_short_specific <- tzdb_entries_tzid[tzdb_idx, "abbrev"]
+  tzdb_idx <- rle(tzdb_entries_tzid$date_start >= input_date)$lengths[1]
 
   # TODO: add check to ensure that the `abbrev` value is a valid
   # short specific non-location time zone
-
-  tz_short_specific
+  tzdb_entries_tzid[tzdb_idx, "abbrev"]
 }
 
 # The long specific non-location format (e.g., 'Pacific Standard Time') from
@@ -462,7 +459,7 @@ get_tz_non_location <- function(
     tz_name <- tz_metazone_names_entry[[available_items]]
   } else if (target_item %in% available_items) {
     tz_name <- tz_metazone_names_entry[[target_item]]
-  } else if (short_long == "short" && !has_short_items) {
+  } else if (!has_short_items && short_long == "short") {
     if (any(grepl(type, available_items))) {
       tz_name <- tz_metazone_names_entry[[paste0("long.", type)]]
     } else {


### PR DESCRIPTION
Just wanted to send that since I had that hanging locally.

a8cc63d96f26cfcb90e336a7bfd930a5a7fccd48 is a nice improvement, since we are able to use the vectorization speed of `grepl()` instead of calling `is_tz_present()` multiple times.

Also added comments to mention that the repeated operation is a WIP (I don't want to put the effort to solve it now since I don't really use this type of date formatting, but wanted to leave a comment in case the code base becomes cryptic over time)